### PR TITLE
20251114 - rotas para criação, busca e apagar laboratórios

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -16,7 +16,15 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 	// Rota para executar um Lab (WebSocket)
 	// ex: WS /api/v1/labs/lab-tf-01/execute
 	g.GET("/labs/:labID/execute", h.HandlerLabExecute)
+
 	
-	// TODO: Adicionar uma rota para listar todos os labs
-	// g.GET("/labs", h.HandleListLabs)
+	
+	// Rota para listar todos os labs
+	g.GET("/labs", h.HandleListLabs)
+
+	// Rota para criar um laboratório
+	g.POST("/labs", h.HandlerCreateLab)
+
+	// Rota para deletar um laboratório
+	g.DELETE("/labs/:labId", h.HandlerDeleteLab)
 }

--- a/internal/repository/sqlite_repo.go
+++ b/internal/repository/sqlite_repo.go
@@ -187,3 +187,28 @@ func (r *sqlRepository) CreateWorkspace(ctx context.Context, labID string) (*dom
 	return &ws, nil
 }
 
+func (r *sqlRepository) CreateLab(ctx context.Context, lab *domain.Lab) error {
+
+	query := `
+		INSERT INTO labs (id, title, type, instructions, initial_code, created_at)
+        VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		lab.ID,
+		lab.Title,
+		lab.Type,
+		lab.Instructions,
+		lab.InitialCode,
+	)
+	return err
+}
+
+func (r *sqlRepository) CleanLab(ctx context.Context, labId string) error {
+	query := `
+		DELETE FROM labs WHERE id = ?
+	`
+
+	_, err := r.db.ExecContext(ctx, query, labId)
+	return err
+}

--- a/internal/service/lab_service.go
+++ b/internal/service/lab_service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"lab-devops/internal/domain"
+
+	"github.com/google/uuid"
 )
 
 type LabService struct {
@@ -88,4 +90,50 @@ func (s *LabService) GetLabDetails(ctx context.Context, labID string) (*domain.L
 	}
 
 	return lab, ws, nil
+}
+
+func (s *LabService) CreateLab(ctx context.Context, title, labType, instructions, initialCode string) (*domain.Lab, error) {
+    // Validação básica
+    if title == "" || labType == "" {
+        return nil, fmt.Errorf("titulo e tipo são obrigatórios")
+    }
+
+    newLab := &domain.Lab{
+        ID:           uuid.New().String(), // Gera um ID único
+        Title:        title,
+        Type:         labType,
+        Instructions: instructions,
+        InitialCode:  initialCode,
+        // CreatedAt será definido pelo banco ou podemos definir aqui se preferir
+    }
+
+    if err := s.repo.CreateLab(ctx, newLab); err != nil {
+        return nil, fmt.Errorf("falha ao criar lab: %w", err)
+    }
+
+    return newLab, nil
+}
+
+func (s *LabService) ListLabs(ctx context.Context) ([]*domain.Lab, error) {
+	labs, err := s.repo.ListLabs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao listar labs: %w", err)
+	}
+	return labs, nil
+}
+
+func (s *LabService) GetWorkspaceState(ctx context.Context, workspaceID string) ([]byte, error) {
+	state, err := s.repo.GetWorkspaceState(ctx, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao obter estado do workspace %s: %w", workspaceID, err)
+	}
+	return state, nil
+}
+
+func (s *LabService) CleanLab(ctx context.Context, labId string) error {
+	err := s.repo.CleanLab(ctx, labId)
+	if err != nil {
+		return fmt.Errorf("erro ao apagar laboratório: %w", err)
+	}
+	return err
 }

--- a/internal/service/ports.go
+++ b/internal/service/ports.go
@@ -29,5 +29,6 @@ type WorkspaceRepository interface {
 	UpdateWorkspaceState(ctx context.Context, workspaceId string, state []byte) error
 	GetWorkspaceState(ctx context.Context, workspaceId string) ([]byte, error)
 	CreateWorkspace(ctx context.Context, labId string) (*domain.Workspace, error)
-
+	CreateLab(ctx context.Context, lab *domain.Lab) error
+	CleanLab(ctx context.Context, labId string) error
 }


### PR DESCRIPTION
# Resumo do Pull Request

**Commit:** 685a9b3d575c9766822a46a446ce902fa2c5ba35
**Autor:** luisfelix-93
**Data:** Fri Nov 14 20:52:30 2025 -0300

**Mensagem do Commit:** 20251114 - rotas para criação, busca e apagar laboratórios

## Descrição

Este commit introduz as rotas de API para gerenciar laboratórios, incluindo a criação, busca e exclusão de laboratórios.

## Arquivos Modificados

- **`internal/api/handler.go`**: Adicionado o handler para as novas rotas de laboratório.
- **`internal/api/routes.go`**: Atualizadas as rotas da API para incluir os novos endpoints de laboratório.
- **`internal/repository/sqlite_repo.go`**: Implementada a lógica de acesso ao banco de dados para as operações de laboratório.
- **`internal/service/lab_service.go`**: Adicionado o serviço que orquestra a lógica de negócios para as operações de laboratório.
- **`internal/service/ports.go`**: Atualizadas as portas de serviço para incluir as novas funcionalidades de laboratório.
